### PR TITLE
Fix socket connecting too early

### DIFF
--- a/neca/statics/lib/core.js
+++ b/neca/statics/lib/core.js
@@ -1,12 +1,15 @@
 // connect a websocket to the server
 
-const SERVER_URL = "localhost:8080"
-var socket = io();
-
-socket.on('connect', function() {
-    console.log("Connected to server");
+const socket = io({
+    autoConnect: false
 });
 
+document.addEventListener("DOMContentLoaded", () => {
+    socket.connect();
+    socket.on('connect', function () {
+        console.log("Connected to server");
+    });
+});
 
 // create new connections between blocks and events
 // when the connect() function is called in the template

--- a/neca/statics/lib/core.js
+++ b/neca/statics/lib/core.js
@@ -4,12 +4,11 @@ const socket = io({
     autoConnect: false
 });
 
-document.addEventListener("DOMContentLoaded", () => {
-    socket.connect();
-    socket.on('connect', function () {
-        console.log("Connected to server");
-    });
+socket.on('connect', function () {
+    console.log("Connected to server");
 });
+
+document.addEventListener("DOMContentLoaded", () => socket.connect());
 
 // create new connections between blocks and events
 // when the connect() function is called in the template


### PR DESCRIPTION
This PR intends to fix a very specific bug that sometimes occurs, namely that `connect_block` might be called after the socket receives messages, which means those messages get discarded. The changes in this PR force the socket to connect after `DOMContentLoaded`, which guarantees that the blocks have been setup.